### PR TITLE
Add environment Rake task.

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -5,7 +5,7 @@ exit_code=0
 echo "*** Running container app specs"
 bundle install | grep Installing
 bundle exec rake db:create db:migrate #don't remove this line. If only run in test our schema.rb doesn't include required engine's migrations
-RAILS_ENV=test bundle exec rake db:create db:migrate
+RAILS_ENV=test bundle exec rake environment db:create db:migrate
 bundle exec rspec spec
 exit_code+=$?
 


### PR DESCRIPTION
This is suggested in [this comment thread](http://pivotallabs.com/leave-your-migrations-in-your-rails-engines/) and fixed an issue I experienced with the `RAILS_ENV=test` Rake run not picking up the engine migrations.
